### PR TITLE
support for indigo and fix for precise and saucy

### DIFF
--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+__author__ = 'fmw-be'

--- a/scripts/core/Callback.py
+++ b/scripts/core/Callback.py
@@ -1,0 +1,27 @@
+import logging
+
+class Callback(object):
+    def __init__(self):
+        self.log = logging.getLogger(__name__)
+        self.log.debug('logging started')
+        self.fncList = dict()
+
+    def register(self, callbackFnc, id=None):
+        self.log.debug('callbackFnc "%s" id "%s"', callbackFnc, id)
+        if id is None:
+            id = object()
+            self.log.debug('creating new id "%s" asd "%s"', id, id)
+        self.fncList[id] = callbackFnc
+        return id
+
+    def unregister(self, id):
+        self.log.debug('check id id-key "%s" is in fncList "%s"', id, self.fncList.keys())
+        if id in self.fncList.keys():
+            self.fncList.pop(id, None)
+
+    def notify(self, msg):
+        self.log.debug('trigger callback-functions "%s"', self.fncList.values())
+        for fnc in self.fncList.values():
+            self.log.debug('call function "%s"', fnc)
+            fnc(msg)
+        return id

--- a/scripts/core/CommandDispatcher2.py
+++ b/scripts/core/CommandDispatcher2.py
@@ -1,0 +1,250 @@
+from Callback import Callback
+
+from subprocess import Popen, PIPE
+import fcntl
+import os
+import time
+from collections import deque
+import errno
+
+import threading
+
+import logging
+
+class BasicLineWrapper(object):
+    def __init__(self, data):
+        self.data = data
+        self.time = time.time()
+
+    def __repr__(self):
+        return '%.6f %s' % (self.time, self.data)
+
+class OutLineWrapper(BasicLineWrapper):
+    def __init__(self, data):
+        super(OutLineWrapper, self).__init__(data)
+
+    def __repr__(self):
+        return 'OUTPUT %s' % super(OutLineWrapper, self).__repr__()
+
+
+class ErrorLineWrapper(BasicLineWrapper):
+    def __init__(self, data):
+        super(ErrorLineWrapper, self).__init__(data)
+
+    def __repr__(self):
+        return 'ERROR  %s' % super(ErrorLineWrapper, self).__repr__()
+
+
+class InLineWrapper(BasicLineWrapper):
+    def __init__(self, data):
+        super(InLineWrapper, self).__init__(data)
+
+    def __repr__(self):
+        return 'INPUT  %s' % super(InLineWrapper, self).__repr__()
+
+
+
+class _DataThread(threading.Thread, Callback):
+    lastGlobalDataTime = time.time()
+    lastGlobalDataTimeLock = threading.Lock()
+
+    def __init__(self, **kwargs):
+        self.log = logging.getLogger(__name__)
+        self.log.debug('init with <%s>', kwargs)
+
+        self.log.debug('call threading.Thread.__init__(self, target=self.run)')
+        threading.Thread.__init__(self, target=self.run)
+        self.log.debug('call Callback.__init__(self)')
+        Callback.__init__(self)
+
+        self.syncThreads=kwargs.get('syncThreads', False)
+        self.commandSleepTime = kwargs['commandSleepTime']
+        self.timeout = kwargs['timeout']
+        self.stdio = kwargs['stdio']
+        self.lastDataTime = None
+
+
+    def updateLastTime(self):
+        self.log.debug('syncThreads-active? "%s"', self.syncThreads)
+        if self.syncThreads:
+            _DataThread.lastGlobalDataTimeLock.acquire()
+            _DataThread.lastGlobalDataTime = time.time()
+            _DataThread.lastGlobalDataTimeLock.release()
+        else:
+            self.lastDataTime = time.time()
+
+
+    def run(self):
+        self.log.debug('THREAD STARTED')
+        self.updateLastTime()
+        while time.time() - self.getLastTime() < self.timeout:
+            try:
+                data = self.stdio.read()
+                self.updateLastTime()
+                self.notify(data)
+            except IOError as ex:
+                if ex.errno is not errno.EWOULDBLOCK:
+                    raise ex
+            finally:
+                time.sleep(self.commandSleepTime)
+
+
+    def getLastTime(self):
+        if self.syncThreads:
+            _DataThread.lastGlobalDataTimeLock.acquire()
+            retval = float(_DataThread.lastGlobalDataTime)
+            _DataThread.lastGlobalDataTimeLock.release()
+        else:
+            retval = self.lastDataTime
+        return retval
+
+class _StdOutHandler(Callback):
+    def __init__(self, lineWrapper=None, **kwargs):
+        self.log = logging.getLogger(__name__)
+        self.log.debug('start logging')
+        Callback.__init__(self)
+        self.lineWrapper = lineWrapper
+        self.stdio = kwargs['stdio']
+        self.dataCallbackFnc = kwargs.get('dataCallbackFnc', None)
+        #self.stdioData = deque()
+
+        # setting stdio-file in non blocking mode
+        fcntl.fcntl(self.stdio.fileno(), fcntl.F_SETFL, os.O_NONBLOCK)
+
+        # create data thread and register data callback
+        self.stdioThread = _DataThread(**kwargs)
+        #self.stdioThread.register(self.stdioData.extend, self)
+        self.stdioThread.register(self.storeData, self)
+
+    def storeData(self, data):
+        #self.stdioData.extend(self.preparingData(data))
+        #self.notify(self.stdioData)
+        self.notify(self.preparingData(data))
+
+    def preparingData(self, data):
+        return [self.lineWrapper(x) if self.lineWrapper else x for x in data.splitlines()]
+
+
+class STDIOTYPE(object):
+    STDOUT = object()
+    STDERR = object()
+
+class CommandDispatcher(Callback):
+
+    def __init__(self, command, stdIOType, command_args=None, cwd=None, **kwargs):
+        self.log = logging.getLogger(__name__)
+        self.log.debug('foo')
+
+        Callback.__init__(self)
+
+        assert isinstance(stdIOType, list)
+        self.timeout = kwargs['timeout']
+        self.commandSleepTime = kwargs['commandSleepTime']
+        self.stdIOType = stdIOType
+        self.stdioData = deque()
+
+        args = [command]
+        if command_args:
+            if not isinstance(command_args, list):
+                command_args = [command_args]
+            args.extend(command_args)
+
+        # create configured process pipes
+        prockwargs = dict()
+        prockwargs['shell'] = False
+        prockwargs['stdin'] = PIPE
+        prockwargs['stdout'] = PIPE if STDIOTYPE.STDOUT in stdIOType else None
+        prockwargs['stderr'] = PIPE if STDIOTYPE.STDERR in stdIOType else None
+        prockwargs['cwd'] = cwd
+
+        # create process
+        self.proc = Popen(args, **prockwargs)
+
+        # create process handler
+
+        self.stdoutHandle = None
+        if STDIOTYPE.STDOUT in stdIOType:
+            self.stdoutHandle = _StdOutHandler(stdio=self.proc.stdout, lineWrapper=OutLineWrapper, **kwargs)
+            self.stdoutHandle.register(self._newDataCallbackFnc)
+
+        self.stderrHandle = None
+        if STDIOTYPE.STDERR in stdIOType:
+            self.stderrHandle = _StdOutHandler(stdio=self.proc.stderr, lineWrapper=ErrorLineWrapper, **kwargs)
+            self.stderrHandle.register(self._newDataCallbackFnc)
+
+        self.stdioHandle = [self.stdoutHandle, self.stderrHandle]
+
+    def _newDataCallbackFnc(self, lines):
+        assert isinstance(lines, list)
+        self.log.debug('extending new data')
+        self.stdioData.extend(lines)
+        self.notify(lines)
+
+    def printData(self, data):
+        for d in data:
+            print d
+
+    def sendCmd(self, command):
+        if isinstance(command, list):
+            map(self.sendCmd, command)
+            return
+
+        self._newDataCallbackFnc([InLineWrapper(command)])
+        cmd = ''.join([command, os.linesep])
+        self.proc.stdin.write(cmd)
+        time.sleep(self.commandSleepTime)  # waiting for not breaking the pipe
+
+
+        self._startDataThreads()
+
+    def _startDataThreads(self):
+        self.log.debug('try starting threads')
+        for stdioHandle in self.stdioHandle:
+            if stdioHandle:
+                self.log.debug('  check if thead is alive')
+                if stdioHandle.stdioThread.isAlive():
+                    self.log.warning('    thread still active')
+                    stdioHandle.stdioThread.updateLastTime()
+                else:
+                    self.log.warning('    thread is dead, try starting')
+                    try:
+                        stdioHandle.stdioThread.start()
+                    except RuntimeError as ex:
+                        self.log.exception(ex)
+
+
+    def join(self):
+        for stdioHandle in self.stdioHandle:
+            stdioHandle.stdioThread.join(self.timeout)
+
+
+def foo(data):
+    foo = data
+    #foo = copy.deepcopy(data)
+    while len(foo):
+        print foo.pop()
+    #while len(data):
+    #    print data.pop()
+
+if __name__ == '__main__':
+    import copy
+    FORMAT = '[%(asctime)s %(filename)s(%(lineno)d):%(threadName)s %(name)s.%(funcName)s] %(levelname)s: %(message)s'
+    DATEFMT = '%Y%m%d %H:%M:%S'
+    logging.basicConfig(format=FORMAT, level=logging.ERROR, datefmt=DATEFMT)
+
+    log = logging.getLogger(__name__)
+    log.debug('#'*100)
+    log.debug('APPLICATION STARTED')
+    log.debug('#'*100)
+
+
+
+    stdIOType = [STDIOTYPE.STDOUT, STDIOTYPE.STDERR]
+    cd = CommandDispatcher('/bin/zsh', stdIOType, dataCallbackFnc=foo, timeout=4, commandSleepTime=0.2, syncThreads=True)
+    cd.register(foo)
+    cd.sendCmd('netstat -a | egrep LISTEN; bbb; echo; w; aaaa')
+    cd.sendCmd('ps fax')
+    cd.join()
+
+    print '='*200
+    print 'FIN'

--- a/scripts/core/__init__.py
+++ b/scripts/core/__init__.py
@@ -1,0 +1,1 @@
+__author__ = 'fmw-be'

--- a/scripts/install_basics.sh
+++ b/scripts/install_basics.sh
@@ -13,12 +13,18 @@ echo -e "\n***UPGRADE***"
 apt-get dist-upgrade -y
 echo -e "\n***INSTALL HELPER***"
 apt-get install -y \
-    python-setuptools ccache wget curl curl-ssl sudo git-buildpackage dput \
+    python-setuptools ccache wget curl sudo git-buildpackage dput \
     python-yaml python-pip python-support python-apt git-core mercurial subversion \
     python-all gccxml python-empy python-nose python-mock python-minimock \
     lsb-release python-numpy python-wxgtk2.8 python-argparse python-networkx \
     graphviz python-sphinx doxygen python-epydoc cmake pkg-config openssh-client python-paramiko \
     cppcheck x11-utils
+
+saucy='saucy'
+if [ $1 != $saucy ]
+then
+    apt-get install -y curl-ssl
+fi
 
 echo -e "\n***GET KEY***"
 wget http://packages.ros.org/ros.key -O - | apt-key add -
@@ -31,28 +37,36 @@ apt-get update
 echo -e "\n***INSTALL ROS***"
 apt-get install -y ros-$2-ros
 
-echo -e "\n***PYPASSING BROKEN DEPENDENCY - INSTALL ROS***"
 
-echo -e "\n### INSTALLING ROS ###"
-apt-get install -y python-vcstools python-rospkg python-routes python-rosdistro python-ropemacs python-rosinstall-generator python-rope python-rosrelease python-rosdep python-roman
-echo -e "\n### DOWNLOAD python-wstool ###"
-apt-get download -y python-wstool
+precise='precise'
+if [ $1 = $precise ]    # string1 has not been declared or initialized.
+then
+    echo -e "\n***PYPASSING BROKEN DEPENDENCY - INSTALL python-wstool***"
 
-echo -e "\n### REMOVING BROKEN DEPENDECY IN PACKAGE python-wstool AND INSTALLING IT ###"
-dpkg-deb -x python-wstool_0.1.4-1_all.deb changedeb
-dpkg-deb --control python-wstool_0.1.4-1_all.deb changedeb/DEBIAN
-mv changedeb/DEBIAN/control changedeb/DEBIAN/control_old
-cat changedeb/DEBIAN/control_old | sed -e 's/, python:any (>= 2.7.1-0ubuntu2)//g' > changedeb/DEBIAN/control
-rm changedeb/DEBIAN/control_old
-dpkg -b changedeb python-wstool_0.1.4-1_all_rmdeb.deb
-rm -rf changedeb/
-rm python-wstool_0.1.4-1_all.deb
-dpkg -i python-wstool_0.1.4-1_all_rmdeb.deb 
-rm python-wstool_0.1.4-1_all_rmdeb.deb
+    echo -e "\n### INSTALLING ROS ###"
+    apt-get install -y python-vcstools python-rospkg python-routes python-rosdistro python-ropemacs python-rosinstall-generator python-rope python-rosrelease python-rosdep python-roman
+    echo -e "\n### DOWNLOAD python-wstool ###"
+    apt-get download -y python-wstool
 
-echo -e "\n### INSTALLING python-rosinstall ###"
-apt-get install -y python-rosinstall
+    echo -e "\n### REMOVING BROKEN DEPENDECY IN PACKAGE python-wstool AND INSTALLING IT ###"
+    dpkg-deb -x python-wstool_0.1.4-1_all.deb changedeb
+    dpkg-deb --control python-wstool_0.1.4-1_all.deb changedeb/DEBIAN
+    mv changedeb/DEBIAN/control changedeb/DEBIAN/control_old
+    cat changedeb/DEBIAN/control_old | sed -e 's/, python:any (>= 2.7.1-0ubuntu2)//g' > changedeb/DEBIAN/control
+    rm changedeb/DEBIAN/control_old
+    dpkg -b changedeb python-wstool_0.1.4-1_all_rmdeb.deb
+    rm -rf changedeb/
+    rm python-wstool_0.1.4-1_all.deb
+    dpkg -i python-wstool_0.1.4-1_all_rmdeb.deb
+    rm python-wstool_0.1.4-1_all_rmdeb.deb
+
+    echo -e "\n### INSTALLING python-rosinstall ###"
+    apt-get install -y python-rosinstall
+fi
+
+echo -e "\n***INSTALL ROS PYTHON TOOLS***"
+apt-get install -y python-ros*
 
 
-#echo -e "\n***INSTALL ROS PYTHON TOOLS***"
-#apt-get install -y python-ros*
+
+

--- a/scripts/pbuilder_calls.py
+++ b/scripts/pbuilder_calls.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import sys
+import os
+import subprocess
+from core.CommandDispatcher2 import CommandDispatcher
+from core.CommandDispatcher2 import STDIOTYPE
+
+
+def fastStdFeedback(data):
+    foo = data
+    while len(foo):
+        print len(foo), foo.pop()
+        sys.stdout.flush()
+
+def fireCommand(command, timeout=180):
+    print 'executing command..'
+    sys.stdout.flush()
+
+    stdIOType = [STDIOTYPE.STDOUT, STDIOTYPE.STDERR]
+    cd = CommandDispatcher('/bin/bash', stdIOType, dataCallbackFnc=fastStdFeedback, timeout=timeout, commandSleepTime=0.2, syncThreads=True)
+    cd.register(fastStdFeedback)
+    cd.sendCmd(' '.join(command))
+    cd.join()
+
+    print '-+-'*20
+    print 'command ending....'
+    print '-+-'*20
+
+
+if __name__ =='__main__':
+    print 'Script arguments are:', sys.argv
+    print
+    print 'os.environ', os.environ
+    print
+
+    job = sys.argv[1]
+
+    if job == 'create':
+        basetgz = sys.argv[2]
+        ubuntu_distro = sys.argv[3]
+        arch = sys.argv[4]
+
+        print 'basetgz', basetgz
+        print 'ubuntu_distro', ubuntu_distro
+        print 'arch', arch
+
+        command = ['sudo', 'pbuilder', '--create', '--basetgz', basetgz,
+                   '--distribution', ubuntu_distro, '--architecture', arch,
+                   '--debootstrapopts', '--variant=buildd', '--components',
+                   '"main universe multiverse"', '--debootstrapopts',
+                   '--keyring=/etc/apt/trusted.gpg', '--timeout', '5m']
+
+        print 'command will be:',  ' '.join(command)
+
+        fireCommand(command)
+
+        #print subprocess.check_output(command, close_fds=True, env=os.environ)
+
+
+    elif job == 'update':
+        basetgz = sys.argv[2]
+
+        print 'basetgz', basetgz
+
+        command = ['sudo', 'pbuilder', '--update', '--basetgz', basetgz]
+
+        print 'command will be:',  ' '.join(command)
+
+        fireCommand(command)
+
+
+    elif job == 'execute':
+        basetgz = sys.argv[2]
+        script_name = sys.argv[3]
+        script_arguments = sys.argv[4:]
+
+        print 'basetgz', basetgz
+        print 'script_name', script_name
+        print 'script_arguments', script_arguments
+
+
+        command = ['sudo', 'pbuilder', '--execute', '--basetgz', basetgz,
+                   '--save-after-exec', '--', script_name, ' '.join(script_arguments)]
+
+        print 'command will be:',  ' '.join(command)
+        fireCommand(command)
+
+    sys.exit()

--- a/scripts/update_chroot_tarballs.py
+++ b/scripts/update_chroot_tarballs.py
@@ -112,6 +112,8 @@ def process_basic_tarball(ssh, basic, local_abs, remote_abs, extended_tarballs, 
     local_abs_basic = os.path.join(local_abs, basic)
     remote_abs_basic = os.path.join(remote_abs, basic)
 
+    sys.stdout.flush()
+
     # get tarball parameter
     tarball_params = get_tarball_params(basic)
     print "tarball parameter: ", tarball_params
@@ -127,16 +129,20 @@ def process_basic_tarball(ssh, basic, local_abs, remote_abs, extended_tarballs, 
 #            get_tarball(ssh, basic, remote_abs_basic, local_abs_basic)
 #
 #            # update tarball
-#            call("./pbuilder_calls.sh update %s" % local_abs_basic)
+#            call("./pbuilder_calls.py update %s" % local_abs_basic)
 #
 #        except Exception as ex:
 #            return ["%s: %s" % (basic, ex)]
 #
 #    else:
+
+    sys.stdout.flush()
     print "Create %s" % basic
+
+    sys.stdout.flush()
     try:
         # create tarball on slave
-        call("./pbuilder_calls.sh create %s %s %s"
+        call("./pbuilder_calls.py create %s %s %s"
              % (local_abs_basic, tarball_params['ubuntu_distro'],
                 tarball_params['arch']))
 
@@ -194,9 +200,9 @@ def process_extend_tarball(ssh, basic, local_abs_basic, extend, local_abs_extend
             get_tarball(ssh, extend, remote_abs_extend, local_abs_extend)
 
             # update tarball
-            #call("./pbuilder_calls.sh update %s" % local_abs_extend)
+            #call("./pbuilder_calls.py update %s" % local_abs_extend)
 
-            call("./pbuilder_calls.sh execute %s install_basics.sh %s %s %s"
+            call("./pbuilder_calls.py execute %s install_basics.sh %s %s %s"
                  % (local_abs_extend, tarball_params['ubuntu_distro'],
                     tarball_params['ros_distro'], apt_cacher_proxy))
 
@@ -208,7 +214,7 @@ def process_extend_tarball(ssh, basic, local_abs_basic, extend, local_abs_extend
         try:
             call("cp %s %s" % (local_abs_basic, local_abs_extend))
 
-            call("./pbuilder_calls.sh execute %s install_basics.sh %s %s %s"
+            call("./pbuilder_calls.py execute %s install_basics.sh %s %s %s"
                  % (local_abs_extend, tarball_params['ubuntu_distro'],
                     tarball_params['ros_distro'], apt_cacher_proxy))
 
@@ -295,17 +301,27 @@ def call_with_list(command, envir=None, verbose=True):
     print "\n********************************************************************"
     print "Executing command '%s'" % ' '.join(command)
     print "********************************************************************"
+
+    sys.stdout.flush()
+
     helper = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True, env=envir)
     res, err = helper.communicate()
+    #res = subprocess.check_output(command, close_fds=True, env=envir)
+    #err = ''
     if verbose:
         print str(res)
     print str(err)
+
+    sys.stdout.flush()
+
+
     if helper.returncode != 0:
         msg = "Failed to execute command '%s'" % command
         print "\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
         print "/!\  %s" % msg
         print "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n"
         raise BuildException(msg)
+
     return res
 
 


### PR DESCRIPTION
indigo: 
reimplementation of the pbuilder_calls script in python. 
process-call behaviour changed by using non-blocking calls to avoid suspended
skript caused by zombie-child-processes. for this the command-dispatcher 
is used. 

precise:
for the python-wstool-package manual intervention due to broken 
package-dependecy is necessary

saucy:
seems that required package curl-ssh only available for lts versions
